### PR TITLE
Feature/top arrow

### DIFF
--- a/su-template/default/method_details/html/method_signature.erb
+++ b/su-template/default/method_details/html/method_signature.erb
@@ -1,0 +1,25 @@
+<h3 class="signature <%= 'first' if @index == 0 %>" id="<%= anchor_for(object) %>">
+  <% if object.tags(:overload).size == 1 %>
+    <%= signature(object.tag(:overload), false) %>
+  <% elsif object.tags(:overload).size > 1 %>
+    <% object.tags(:overload).each do |overload| %>
+      <span class="overload"><%= signature(overload, false) %></span>
+    <% end %>
+  <% else %>
+    <%= signature(object, false) %>
+  <% end %>
+
+  <% if object.aliases.size > 0 %>
+    <span class="aliases">Also known as:
+    <span class="names"><%= object.aliases.map {|o|
+      "<span id='#{anchor_for(o)}'>" + h(o.name.to_s) + "</span>" }.join(", ") %></span>
+    </span>
+  <% end %>
+
+  <% if owner != object.namespace %>
+    <span class="not_defined_here">
+      Originally defined in <%= object.namespace.type %>
+        <%= linkify object, owner.relative_path(object.namespace) %>
+    </span>
+  <% end %>
+</h3>

--- a/su-template/default/method_details/html/method_signature.erb
+++ b/su-template/default/method_details/html/method_signature.erb
@@ -1,4 +1,5 @@
 <h3 class="signature <%= 'first' if @index == 0 %>" id="<%= anchor_for(object) %>">
+  <a style="float: right;" href="#header" title="Return to Top">&uarr;</a>
   <% if object.tags(:overload).size == 1 %>
     <%= signature(object.tag(:overload), false) %>
   <% elsif object.tags(:overload).size > 1 %>


### PR DESCRIPTION
This adds an "Return to top" of page up-arrow link to each method signature. See blue circle in image.  This is mainly to compensate for the lack of a working back-button.

![2016-12-25_112514](https://cloud.githubusercontent.com/assets/137514/21472031/7830b568-ca95-11e6-8642-f10ba8e9fe10.png)
