### PR TITLE
OneBox Meta Headers for Embedding Information

### DIFF
--- a/su-template/default/layout/html/embed_meta.erb
+++ b/su-template/default/layout/html/embed_meta.erb
@@ -12,7 +12,7 @@
       su_page_title = h @page_title
       su_page_desc  = @file.title
     elsif @contents
-      # What is this attrbute ? See: "layout/html/setup.rb"
+      # What is this attribute ? See: "layout/html/setup.rb"
     else # object is a YARD::CodeObjects::Base subclass
       su_page_url   = "http://ruby.sketchup.com/#{@path.gsub('::','/')}.html"
       su_page_title = h @page_title

--- a/su-template/default/layout/html/embed_meta.erb
+++ b/su-template/default/layout/html/embed_meta.erb
@@ -1,0 +1,52 @@
+<%  su_site_name = h options.title
+    if @index || object == "_index.html" || object == "index.html"
+      if object == "_index.html" || object == "index.html"
+        su_page_url = "http://ruby.sketchup.com/index.html"
+      else
+        su_page_url = "http://ruby.sketchup.com/"+object
+      end
+      su_page_title = "Alphabetic Index"
+      su_page_desc  = "Alphabetic Index of Files and API Namespaces. This is the main landing page for the SketchUp Ruby API Documentation."
+    elsif @file # generating an YARD::CodeObjects::ExtraFileObject
+      su_page_url   = "http://ruby.sketchup.com/file.#{File.basename(@file.filename,'.*')}.html"
+      su_page_title = h @page_title
+      su_page_desc  = @file.title
+    elsif @contents
+      # What is this attrbute ? See: "layout/html/setup.rb"
+    else # object is a YARD::CodeObjects::Base subclass
+      su_page_url   = "http://ruby.sketchup.com/#{@path.gsub('::','/')}.html"
+      su_page_title = h @page_title
+      if !object.respond_to?(:docstring)
+        su_page_desc = object.is_a?(String) ? object.gsub(/[{}+]/,'')[0..127] : "" %>
+      <!-- <%= "YARD Error - No docstring method for type: #{object.class.name}" %>--><%
+      elsif object.docstring.blank?
+        su_page_desc = ""%>
+      <!-- <%= "YARD Warning - Blank docstring, object is: #{object.class.name}" %>--><%
+      else
+        su_page_desc = object.docstring.summary.gsub(/[{}+]/,'')
+      end
+    end
+    su_page_img = "http://developer.sketchup.com/sites/developers.sketchup.com/files/Ruby.svg"
+%>
+  <!-- GENERIC META PROPERTIES -->
+    <meta name="url"   content="<%= su_page_url %>" />
+    <meta name="image" content="<%= su_page_img %>?s=60" />
+    <meta name="title" content="<%= su_page_title %>" />
+    <meta name="name"  content="<%= su_site_name %>" />
+    <meta name="description" content="<%= su_page_desc %>" />
+  <!-- OPEN GRAPH META PROPERTIES -->
+    <meta property="og:site_name" content="<%= su_site_name %>" />
+    <meta property="og:type"      content="website" />
+    <meta property="og:image"     content="<%= su_page_img %>" />
+    <meta property="og:image:width"  content="60" />
+    <meta property="og:image:height" content="60" />
+    <meta property="og:title"     content="<%= su_page_title %>" />
+    <meta property="og:url"       content="<%= su_page_url %>" />
+    <meta property="og:description" content="<%= su_page_desc %>" />
+  <!-- TWITTER CARD META PROPERTIES -->
+    <meta name="twitter:card"  content="summary"   />
+    <meta name="twitter:site"  content="@sketchup" />
+    <meta name="twitter:title" content="<%= su_page_title %>" />
+    <meta name="twitter:description" content="<%= su_page_desc %>" />
+    <meta name="twitter:image:src"   content="<%= su_page_img %>?s=120" />
+    <meta name="twitter:url"   content="<%= su_page_url %>" />

--- a/su-template/default/layout/html/embed_meta.erb
+++ b/su-template/default/layout/html/embed_meta.erb
@@ -1,29 +1,55 @@
 <%  su_site_name = h options.title
-    if @index || object == "_index.html" || object == "index.html"
+    case object
+    when String
       if object == "_index.html" || object == "index.html"
         su_page_url = "http://ruby.sketchup.com/index.html"
+        su_page_title = "Alphabetic Index"
+        su_page_desc  = "Alphabetic Index of Files and API Namespaces. This is the main landing page for the SketchUp Ruby API Documentation."
       else
-        su_page_url = "http://ruby.sketchup.com/"+object
+        su_page_url = "http://ruby.sketchup.com/"+(object =~ /(.html)\z/ ? object : "#{File.basename(object,'.*')}.html" )
+        su_page_title = (@page_title && !@page_title.empty?) ? (h @page_title) : object.split('.')[0]
+        su_page_desc  = "The #{su_page_title} page."
       end
-      su_page_title = "Alphabetic Index"
-      su_page_desc  = "Alphabetic Index of Files and API Namespaces. This is the main landing page for the SketchUp Ruby API Documentation."
-    elsif @file # generating an YARD::CodeObjects::ExtraFileObject
-      su_page_url   = "http://ruby.sketchup.com/file.#{File.basename(@file.filename,'.*')}.html"
-      su_page_title = h @page_title
-      su_page_desc  = @file.title
-    elsif @contents
-      # What is this attribute ? See: "layout/html/setup.rb"
-    else # object is a YARD::CodeObjects::Base subclass
-      su_page_url   = "http://ruby.sketchup.com/#{@path.gsub('::','/')}.html"
-      su_page_title = h @page_title
-      if !object.respond_to?(:docstring)
-        su_page_desc = object.is_a?(String) ? object.gsub(/[{}+]/,'')[0..127] : "" %>
-      <!-- <%= "YARD Error - No docstring method for type: #{object.class.name}" %>--><%
-      elsif object.docstring.blank?
-        su_page_desc = ""%>
+    when YARD::CodeObjects::Base # or subclass
+      if object.root? 
+        if @file # Generating a YARD::CodeObjects::ExtraFileObject
+          su_page_url   = "http://ruby.sketchup.com/file.#{File.basename(@file.filename,'.*')}.html"
+          su_page_title = h @page_title
+          su_page_desc  = @file.title
+        elsif h @page_title == "Top Level Namespace"
+          su_page_url   = "http://ruby.sketchup.com/top-level-namespace.html"
+          su_page_title = h @page_title
+          su_page_desc  = "The Top Level Namespace for Ruby and the SketchUp API, listing global constants, and a summary of toplevel modules and classes."
+        else %>
+      <!-- <%= "YARD Error - (embed_meta.erb) Unknown root object - using site name." %>--><%
+          su_page_title = su_site_name
+          su_page_url   = "http://ruby.sketchup.com/"
+          su_page_desc  = "#{su_site_name}."
+        end
+      else # Generating a Class or Module page:
+        su_page_url   = "http://ruby.sketchup.com/#{@path.gsub('::','/')}.html"
+        su_page_title = h @page_title
+        if object.docstring.blank?
+          if object.is_a?(YARD::CodeObjects::ClassObject)
+            su_page_desc = "The #{@path} class."
+          elsif object.is_a?(YARD::CodeObjects::ModuleObject)
+            su_page_desc = "The #{@path} module."
+          else
+            su_page_desc = "The #{su_page_title} page."
+          end %>
       <!-- <%= "YARD Warning - Blank docstring, object is: #{object.class.name}" %>--><%
-      else
+        else
+          su_page_desc = object.docstring.summary.gsub(/[{}+]/,'')
+        end
+      end # if root object
+    else # object is unexpected type %>
+      <!-- <%= "YARD Error - (embed_meta.erb) Unexpected type: #{object.class.name}" %>--><%
+      su_page_title = su_site_name
+      su_page_url   = "http://ruby.sketchup.com/"
+      if object.respond_to?(:docstring)
         su_page_desc = object.docstring.summary.gsub(/[{}+]/,'')
+      else
+        su_page_desc  = "#{su_site_name}."
       end
     end
     su_page_img = "http://developer.sketchup.com/sites/developers.sketchup.com/files/Ruby.svg"

--- a/su-template/default/layout/html/headers.erb
+++ b/su-template/default/layout/html/headers.erb
@@ -1,0 +1,15 @@
+  <meta charset="<%= charset %>">
+  <!-- VIEWPORT -->
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <!-- AUTHOR and GENERATOR -->
+    <meta name="author" content="SketchUp Extensibility Team">
+    <meta name="generator" content="YARD <%= YARD::VERSION %> (ruby-<%= RUBY_VERSION %>) http://yardoc.org">
+  <!-- TITLE -->
+    <title><% if @index %>
+    Alphabetic Index &mdash; <%= h options.title %><% else %>
+    <%= h @page_title %><% if options.title && @page_title != options.title %> &mdash; <%= h options.title %><% end %><% end %>
+    </title>
+  <!-- SHORTCUT ICON -->
+    <link rel="shortcut icon" type="image/vnd.microsoft.icon"
+    href="https://help.sketchup.com/sites/all/themes/sketch_help/favicon.ico" />
+<%= erb(:embed_meta) %>

--- a/su-template/default/layout/html/headers.erb
+++ b/su-template/default/layout/html/headers.erb
@@ -3,9 +3,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <!-- AUTHOR and GENERATOR -->
     <meta name="author" content="SketchUp Extensibility Team">
-    <meta name="generator" content="YARD <%= YARD::VERSION %> (ruby-<%= RUBY_VERSION %>) http://yardoc.org">
+    <meta name="generator" content="YARD http://yardoc.org">
   <!-- TITLE -->
-    <title><% if @index %>
+    <title><% if object == "_index.html" || object == "index.html" %>
     Alphabetic Index &mdash; <%= h options.title %><% else %>
     <%= h @page_title %><% if options.title && @page_title != options.title %> &mdash; <%= h options.title %><% end %><% end %>
     </title>

--- a/su-template/default/layout/html/layout.erb
+++ b/su-template/default/layout/html/layout.erb
@@ -2,23 +2,28 @@
 <html>
 <head>
   <%= erb(:headers) %>
-  <link rel="shortcut icon" type="image/vnd.microsoft.icon"
-    href="https://help.sketchup.com/sites/all/themes/sketch_help/favicon.ico">
-  <link rel='stylesheet' type='text/css'
-    href='https://fonts.googleapis.com/css?family=Open+Sans:400,700,400italic'>
-  
-  <script>
-    // Every time this page is loaded, it sends this action to SketchUp, telling
-    // SketchUp that a new page has loaded that has example snippets that should
-    // be replaced with code editors. Nothing happens if the page is loaded in a
-    // regular browser outside of the SketchUp client.
-    $( document ).ready(function() {
-      if (typeof sketchup == 'object') { 
-         sketchup.page_loaded();
-      }
-    });
-  </script>
-  
+  <!-- STYLESHEETS -->
+    <link rel="stylesheet" type="text/css"
+    href="https://fonts.googleapis.com/css?family=Open+Sans:400,700,400italic" />
+<% stylesheets.each do |stylesheet| %>
+    <link rel="stylesheet" href="<%= url_for(stylesheet) %>" type="text/css" charset="utf-8" />
+<% end %>
+  <!-- SCRIPTS -->
+<%= erb :script_setup %>
+<% javascripts.each do |javascript| %>
+    <script type="text/javascript" charset="utf-8" src="<%= url_for(javascript) %>"></script>
+<% end %>
+    <script>
+        // Every time this page is loaded, it sends this action to SketchUp, telling
+        // SketchUp that a new page has loaded that has example snippets that should
+        // be replaced with code editors. Nothing happens if the page is loaded in a
+        // regular browser outside of the SketchUp client.
+        $( document ).ready(function() {
+            if (typeof sketchup == 'object') { 
+                sketchup.page_loaded();
+            }
+        });
+    </script>
 </head>
 <body>
 

--- a/su-template/default/layout/html/layout.erb
+++ b/su-template/default/layout/html/layout.erb
@@ -4,7 +4,7 @@
   <%= erb(:headers) %>
   <!-- STYLESHEETS -->
     <link rel="stylesheet" type="text/css"
-    href="https://fonts.googleapis.com/css?family=Open+Sans:400,700,400italic" />
+      href="https://fonts.googleapis.com/css?family=Open+Sans:400,700,400italic" />
 <% stylesheets.each do |stylesheet| %>
     <link rel="stylesheet" href="<%= url_for(stylesheet) %>" type="text/css" charset="utf-8" />
 <% end %>

--- a/su-template/default/layout/html/layout.erb
+++ b/su-template/default/layout/html/layout.erb
@@ -43,6 +43,8 @@
         <div class="clear"></div>
       </div>
 
+      <iframe id="search_frame" src="<%= @nav_url %>"></iframe>
+
       <div id="content"><%= yieldall %></div>
 
       <%= erb(:footer) %>

--- a/su-template/default/layout/html/layout.erb
+++ b/su-template/default/layout/html/layout.erb
@@ -14,16 +14,17 @@
     <script type="text/javascript" charset="utf-8" src="<%= url_for(javascript) %>"></script>
 <% end %>
     <script>
-        // Every time this page is loaded, it sends this action to SketchUp, telling
-        // SketchUp that a new page has loaded that has example snippets that should
-        // be replaced with code editors. Nothing happens if the page is loaded in a
-        // regular browser outside of the SketchUp client.
-        $( document ).ready(function() {
-            if (typeof sketchup == 'object') { 
-                sketchup.page_loaded();
-            }
-        });
+      // Every time this page is loaded, it sends this action to SketchUp, telling
+      // SketchUp that a new page has loaded that has example snippets that should
+      // be replaced with code editors. Nothing happens if the page is loaded in a
+      // regular browser outside of the SketchUp client.
+      $( document ).ready(function() {
+        if (typeof sketchup == 'object') {
+          sketchup.page_loaded();
+        }
+      });
     </script>
+
 </head>
 <body>
 
@@ -42,8 +43,6 @@
         <%= erb(:search) %>
         <div class="clear"></div>
       </div>
-
-      <iframe id="search_frame" src="<%= @nav_url %>"></iframe>
 
       <div id="content"><%= yieldall %></div>
 


### PR DESCRIPTION
Reorganizes API doc page head sections and adds embedding information as
meta elements. Meant to support Discourse OneBox and Twitter Summary
cards, (as a minimum) for displaying API Documentation page information.

_REF:_ Issue #18 